### PR TITLE
Add support for ordinal buffer numbering

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This plugin provides bufferline functionality for the [lightline](https://github
 - [Installation](#installation)
 - [Integration](#integration)
 - [Configuration](#configuration)
+- [Mappings](#mappings)
 - [Example](#example)
 - [License](#license)
 
@@ -49,10 +50,33 @@ Defines whether to shorten the path using the `pathshorten` function. Default is
 ##### `g:lightline#bufferline#show_number`
 
 Defines whether to add the buffer number to the buffer name. Default is `0`.
+Valid values are:
+* `0`: No numbers
+* `1`: Buffer number as shown by the `:ls` command
+* `2`: Ordinal number (buffers are numbered from *1* to *n* sequentially)
 
 ##### `g:lightline#bufferline#unnamed`
 
 The name to use for unnamed buffers. Default is `'*'`.
+
+## Mappings
+
+This plugin provides Plug mappings to switch to buffers using their ordinal number in the bufferline.
+To display the ordinal numbers in the bufferline use the setting `g:lightline#bufferline#show_number = 2`.
+
+To use the Plug mappings you can use e.g. these mappings:
+```viml
+nmap <Leader>1 <Plug>lightline#bufferline#go(1)
+nmap <Leader>2 <Plug>lightline#bufferline#go(2)
+nmap <Leader>3 <Plug>lightline#bufferline#go(3)
+nmap <Leader>4 <Plug>lightline#bufferline#go(4)
+nmap <Leader>5 <Plug>lightline#bufferline#go(5)
+nmap <Leader>6 <Plug>lightline#bufferline#go(6)
+nmap <Leader>7 <Plug>lightline#bufferline#go(7)
+nmap <Leader>8 <Plug>lightline#bufferline#go(8)
+nmap <Leader>9 <Plug>lightline#bufferline#go(9)
+nmap <Leader>0 <Plug>lightline#bufferline#go(10)
+```
 
 ## Example
 

--- a/autoload/lightline/bufferline.vim
+++ b/autoload/lightline/bufferline.vim
@@ -13,37 +13,65 @@ let s:shorten_path      = get(g:, 'lightline#bufferline#shorten_path', 1)
 let s:show_number       = get(g:, 'lightline#bufferline#show_number', 0)
 let s:unnamed           = get(g:, 'lightline#bufferline#unnamed', '*')
 
-function! s:get_buffer_name(i)
-  let l:name = fnamemodify(bufname(a:i), s:filename_modifier)
+function! s:get_buffer_name(i, buffer)
+  let l:name = fnamemodify(bufname(a:buffer), s:filename_modifier)
   if l:name == ''
     let l:name = s:unnamed
   elseif s:shorten_path
     let l:name = pathshorten(l:name)
   endif
-  if getbufvar(a:i, '&mod')
+  if getbufvar(a:buffer, '&mod')
     let l:name .= s:modified
   endif
-  if s:show_number
-    let l:name = a:i . ' ' . l:name
+  if s:show_number == 1
+    let l:name = a:buffer . ' ' . l:name
+  elseif s:show_number == 2
+    let l:name = (a:i + 1) . ' ' . l:name
   endif
   return substitute(l:name, '%', '%%', 'g')
 endfunction
 
-function! s:get_buffer_names(from, to)
-  let l:i = a:from
-  let l:buffers = []
-  while l:i <= a:to
-    if bufexists(l:i) && buflisted(l:i)
-      call add(l:buffers, s:get_buffer_name(l:i))
-    endif
-    let l:i += 1
-  endwhile
-  return l:buffers
+function! s:filter_buffer(i)
+  return bufexists(a:i) && buflisted(a:i)
+endfunction
+
+function! s:filtered_buffers()
+  return filter(range(1, bufnr('$')), 's:filter_buffer(v:val)')
+endfunction
+
+function! s:goto_nth_buffer(n)
+  let l:buffers = s:filtered_buffers()
+  if a:n < len(l:buffers)
+    execute 'b' . l:buffers[a:n]
+  endif
+endfunction
+
+function! s:get_buffer_names(buffers, from, to)
+  let l:names = []
+  for l:i in range(a:from, a:to - 1)
+    call add(l:names, s:get_buffer_name(l:i, a:buffers[l:i]))
+  endfor
+  return l:names
 endfunction
 
 function! lightline#bufferline#buffers()
-  let l:current = bufnr('%')
-  return [s:get_buffer_names(1, l:current - 1),
-        \ s:get_buffer_names(l:current, l:current),
-        \ s:get_buffer_names(l:current + 1, bufnr('$'))]
+  let l:buffers = s:filtered_buffers()
+  let l:current = index(l:buffers, bufnr('%'))
+  if l:current == -1
+    return [s:get_buffer_names(l:buffers, 0, len(l:buffers)), [], []]
+  endif
+  return [s:get_buffer_names(l:buffers, 0, l:current),
+        \ s:get_buffer_names(l:buffers, l:current, l:current + 1),
+        \ s:get_buffer_names(l:buffers, l:current + 1, len(l:buffers))]
 endfunction
+
+noremap <silent> <Plug>lightline#bufferline#go(1)  :call <SID>goto_nth_buffer(0)<CR>
+noremap <silent> <Plug>lightline#bufferline#go(2)  :call <SID>goto_nth_buffer(1)<CR>
+noremap <silent> <Plug>lightline#bufferline#go(3)  :call <SID>goto_nth_buffer(2)<CR>
+noremap <silent> <Plug>lightline#bufferline#go(4)  :call <SID>goto_nth_buffer(3)<CR>
+noremap <silent> <Plug>lightline#bufferline#go(5)  :call <SID>goto_nth_buffer(4)<CR>
+noremap <silent> <Plug>lightline#bufferline#go(6)  :call <SID>goto_nth_buffer(5)<CR>
+noremap <silent> <Plug>lightline#bufferline#go(7)  :call <SID>goto_nth_buffer(6)<CR>
+noremap <silent> <Plug>lightline#bufferline#go(8)  :call <SID>goto_nth_buffer(7)<CR>
+noremap <silent> <Plug>lightline#bufferline#go(9)  :call <SID>goto_nth_buffer(8)<CR>
+noremap <silent> <Plug>lightline#bufferline#go(10) :call <SID>goto_nth_buffer(9)<CR>


### PR DESCRIPTION
Ordinal buffer numbers can be displayed in the bufferline.
Plug mappings are provided to  switch to buffers using
their ordinal number.

Fixes #2.
