### PR TITLE
Add option to only display the filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ The indicator to use for a modified buffer. Default is `'+'`.
 
 The indicator to use for a read-only buffer. Default is `'-'`.
 
+##### `g:lightline#bufferline#omit_path`
+
+Only display the filename in a path. Default is `0`.
+
 ##### `g:lightline#bufferline#shorten_path`
 
 Defines whether to shorten the path using the `pathshorten` function. Default is `1`.

--- a/autoload/lightline/bufferline.vim
+++ b/autoload/lightline/bufferline.vim
@@ -11,6 +11,7 @@ let s:filename_modifier = get(g:, 'lightline#bufferline#filename_modifier', ':.'
 let s:modified          = get(g:, 'lightline#bufferline#modified', '+')
 let s:read_only         = get(g:, 'lightline#bufferline#read_only', '-')
 let s:shorten_path      = get(g:, 'lightline#bufferline#shorten_path', 1)
+let s:omit_path         = get(g:, 'lightline#bufferline#omit_path', 0)
 let s:show_number       = get(g:, 'lightline#bufferline#show_number', 0)
 let s:unnamed           = get(g:, 'lightline#bufferline#unnamed', '*')
 
@@ -18,6 +19,8 @@ function! s:get_buffer_name(i, buffer)
   let l:name = fnamemodify(bufname(a:buffer), s:filename_modifier)
   if l:name == ''
     let l:name = s:unnamed
+  elseif s:omit_path
+    let l:name = substitute(l:name, '^.*[\\\/]', '', '')
   elseif s:shorten_path
     let l:name = pathshorten(l:name)
   endif


### PR DESCRIPTION
Hi,

Often the displayed paths can get quite long especially in combination with the [ctrlp](https://github.com/kien/ctrlp.vim) plugin thus I propose an additional option `omit_path` that only shows the actual filename.