### PR TITLE
Modify filename only if is a named buffer

### DIFF
--- a/autoload/lightline/bufferline.vim
+++ b/autoload/lightline/bufferline.vim
@@ -15,11 +15,14 @@ let s:show_number       = get(g:, 'lightline#bufferline#show_number', 0)
 let s:unnamed           = get(g:, 'lightline#bufferline#unnamed', '*')
 
 function! s:get_buffer_name(i, buffer)
-  let l:name = fnamemodify(bufname(a:buffer), s:filename_modifier)
+  let l:name = bufname(a:buffer)
   if l:name == ''
     let l:name = s:unnamed
-  elseif s:shorten_path
-    let l:name = pathshorten(l:name)
+  else
+    let l:name = fnamemodify(l:name, s:filename_modifier)
+    if s:shorten_path
+      let l:name = pathshorten(l:name)
+    endif
   endif
   if s:is_read_only(a:buffer)
     let l:name .= ' ' . s:read_only


### PR DESCRIPTION
The current code does not allow using the following config, it will not respect the `unnamed` parameter.

```
let g:lightline#bufferline#filename_modifier = ':~:.'
let g:lightline#bufferline#unnamed = '[No name]'
```

The fix is to first check if the buffer is named or not, and only after that apply filename modifier.