### PR TITLE
Fix buffer selection logic

### DIFF
--- a/autoload/lightline/bufferline.vim
+++ b/autoload/lightline/bufferline.vim
@@ -109,10 +109,10 @@ function! s:select_buffers(before, current, after)
   " Handle empty list carefully, slices are inclusive
   let l:before = l:left == 0 ? [] : a:before[-l:left:]
 
-  " If one buffer on the right size was added, maybe more can fit?
+  " If one buffer on the right was added, maybe more can fit?
   if l:initial_right > 0
     " Fill up the remaining space with buffers on the right
-    let [l:width, l:right] = s:fit_lengths(l:after_lengths[1:], l:width)
+    let [l:width, l:right] = s:fit_lengths(l:after_lengths[l:initial_right:], l:width)
     " Keep track of the one buffer that was added earlier
     let l:right += l:initial_right
   endif

--- a/autoload/lightline/bufferline.vim
+++ b/autoload/lightline/bufferline.vim
@@ -94,21 +94,34 @@ function! s:select_buffers(before, current, after)
     return [a:before, a:current, a:after]
   endif
 
-  " Add one buffer on the right
+  let l:initial_right = 0
+  let l:right = 0
+  let l:left = 0
+
+  " Add one buffer on the right if there is enough space for it
   if len(l:after_lengths) > 0
-    let l:width -= l:after_lengths[0]
+    let [l:width, l:initial_right] = s:fit_lengths(l:after_lengths[:0], l:width)
   endif
 
-  " Add as many buffers as possible from on the left
-  let [l:width, l:left] = s:fit_lengths(l:before_lengths, l:width)
-  let l:before = a:before[-l:left:]
+  " Add as many buffers as possible on the left
+  " Don't forget to use the 'before' list in reversed order
+  let [l:width, l:left] = s:fit_lengths(reverse(l:before_lengths), l:width)
+  " Handle empty list carefully, slices are inclusive
+  let l:before = l:left == 0 ? [] : a:before[-l:left:]
 
-  " Fill up the remaining space with buffers on the right
-  " And keep track of the one buffer that was added earlier
-  let [l:width, l:right] = s:fit_lengths(l:after_lengths[1:], l:width)
-  let l:right += 1
+  " If one buffer on the right size was added, maybe more can fit?
+  if l:initial_right > 0
+    " Fill up the remaining space with buffers on the right
+    let [l:width, l:right] = s:fit_lengths(l:after_lengths[1:], l:width)
+    " Keep track of the one buffer that was added earlier
+    let l:right += l:initial_right
+  endif
 
-  return [a:before[-l:left:], a:current, a:after[:l:right]]
+  " Subtract 1 to account for slices being inclusive, i.e. list[:1] returns two results.
+  " Also handle empty lists carefully.
+  let l:after = l:right == 0 ? [] : a:after[:l:right-1]
+
+  return [l:before, a:current, l:after]
 endfunction
 
 function! s:is_read_only(buffer)


### PR DESCRIPTION
The buffer selection logic is nice, I like it, but there are a few bugs, mostly related to the fact that slices in vim are inclusive, which causes to one more buffer to be shown than necessary.

This caused current buffer being sometimes only partially visible, or in unfortunate cases even completely invisible:

![image](https://user-images.githubusercontent.com/1177900/32203849-30565f78-bde6-11e7-9c9f-d6fb5d34e1a7.png)