### PR TITLE
 Add indicator that there are more invisible buffers

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ The filename-modifier applied to each buffer name. Default is `':.'`.
 
 The indicator to use for a modified buffer. Default is `'+'`.
 
+##### `g:lightline#bufferline#more_buffers`
+
+The indicator to use when there are buffers that are not shown on the bufferline because they didn't fit the available space. Default is `…`.
+
 ##### `g:lightline#bufferline#read_only`
 
 The indicator to use for a read-only buffer. Default is `'-'`.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The indicator to use for a modified buffer. Default is `'+'`.
 
 ##### `g:lightline#bufferline#more_buffers`
 
-The indicator to use when there are buffers that are not shown on the bufferline because they didn't fit the available space. Default is `…`.
+The indicator to use when there are buffers that are not shown on the bufferline because they didn't fit the available space. Default is `...`.
 
 ##### `g:lightline#bufferline#read_only`
 

--- a/autoload/lightline/bufferline.vim
+++ b/autoload/lightline/bufferline.vim
@@ -13,7 +13,7 @@ let s:read_only         = get(g:, 'lightline#bufferline#read_only', '-')
 let s:shorten_path      = get(g:, 'lightline#bufferline#shorten_path', 1)
 let s:show_number       = get(g:, 'lightline#bufferline#show_number', 0)
 let s:unnamed           = get(g:, 'lightline#bufferline#unnamed', '*')
-let s:more_buffers      = get(g:, 'lightline#bufferline#more_buffers', '…')
+let s:more_buffers      = get(g:, 'lightline#bufferline#more_buffers', '...')
 
 let s:more_buffers_width = len(s:more_buffers) + 2
 


### PR DESCRIPTION
I was toying with an idea to show an indicator that there are more buffers that can currently fit the bufferline.

This has to be merged after #10 to simplify the diff, but so far it looks like this:

![more_buffers_indicator](https://user-images.githubusercontent.com/1177900/32244833-1510ea3c-be7a-11e7-84ab-b149114df6c4.gif)

Let me know what you think about it 🙂