### PR TITLE
Add g:lightline#bufferline#number_map

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,23 @@ Valid values are:
 * `1`: Buffer number as shown by the `:ls` command
 * `2`: Ordinal number (buffers are numbered from *1* to *n* sequentially)
 
+##### `g:lightline#bufferline#number_map`
+
+Dictionary mapping ordinal numbers (0-9) to their alternate character representations. Default is `{}`.
+
+For example, to use unicode superscript symbols:
+```viml
+let g:lightline#bufferline#number_map = {
+\ 0: '⁰', 1: '¹', 2: '²', 3: '³', 4: '⁴',
+\ 5: '⁵', 6: '⁶', 7: '⁷', 8: '⁸', 9: '⁹'
+\ }
+```
+
+When a mapping exists, no space is added before the buffer name.
+Any desired spacing needs to be explicitly included as part of the mapped string.
+
+*Note: The option only applies when `g:lightline#bufferline#show_number = 2`.*
+
 ##### `g:lightline#bufferline#unnamed`
 
 The name to use for unnamed buffers. Default is `'*'`.

--- a/autoload/lightline/bufferline.vim
+++ b/autoload/lightline/bufferline.vim
@@ -8,6 +8,7 @@ endif
 let g:loaded_lightline_bufferline = 1
 
 let s:filename_modifier = get(g:, 'lightline#bufferline#filename_modifier', ':.')
+let s:number_map        = get(g:, 'lightline#bufferline#number_map', {})
 let s:shorten_path      = get(g:, 'lightline#bufferline#shorten_path', 1)
 let s:show_number       = get(g:, 'lightline#bufferline#show_number', 0)
 let s:unnamed           = get(g:, 'lightline#bufferline#unnamed', '*')
@@ -42,7 +43,7 @@ function! s:get_buffer_name(i, buffer)
   if s:show_number == 1
     let l:name = a:buffer . ' ' . l:name
   elseif s:show_number == 2
-    let l:name = (a:i + 1) . ' ' . l:name
+    let l:name = get(s:number_map, a:i + 1, (a:i + 1) . ' ') . l:name
   endif
   return substitute(l:name, '%', '%%', 'g')
 endfunction


### PR DESCRIPTION
This configuration option lets you map ordinal numbers (0-9) to their
alternate character representations. It allows you to optionally use
Unicode superscript symbols, for example, which saves space.

This only applies when `g:lightline#bufferline#show_number = 2`.