### PR TITLE
Add lightline#bufferline#buffer_count()

### DIFF
--- a/autoload/lightline/bufferline.vim
+++ b/autoload/lightline/bufferline.vim
@@ -193,6 +193,10 @@ function! lightline#bufferline#buffers()
   return s:select_buffers(l:before, l:current, l:after)
 endfunction
 
+function! lightline#bufferline#buffer_count()
+  return len(s:filtered_buffers())
+endfunction
+
 noremap <silent> <Plug>lightline#bufferline#go(1)  :call <SID>goto_nth_buffer(0)<CR>
 noremap <silent> <Plug>lightline#bufferline#go(2)  :call <SID>goto_nth_buffer(1)<CR>
 noremap <silent> <Plug>lightline#bufferline#go(3)  :call <SID>goto_nth_buffer(2)<CR>


### PR DESCRIPTION
This function exposes the current filtered buffer count as a number,
which allows users to build their own tabline "auto show/hide"
functionality.

For example:

```viml
function! s:auto_tabline(buffer_count) abort
  if a:buffer_count >= 2
    if &showtabline != 2 && &lines > 3
      set showtabline=2
    endif
  else
    if &showtabline != 0
      set showtabline=0
    endif
  endif
endfunction

augroup LightlineAutoCommands
  autocmd!
  autocmd BufEnter  * call <sid>auto_tabline(lightline#bufferline#buffer_count())
  autocmd BufUnload * call <sid>auto_tabline(lightline#bufferline#buffer_count() - 1)
augroup END
```