### PR TITLE
Automatically show tabline based on buffer count

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,12 @@ If set to `1` the symbols `+`, `-` and `...` are replaced by `✎`, `` and `�
 
 *Note: The symbols are only correctly displayed if your font supports these characters.*
 
+##### `g:lightline#bufferline#min_buffer_count`
+
+The minimum number of buffers needed to automatically show the tabline.
+When the buffer count falls below this number, the tabline will be hidden once again.
+Default is `0` (no auto-show behavior).
+
 ## Mappings
 
 This plugin provides Plug mappings to switch to buffers using their ordinal number in the bufferline.

--- a/autoload/lightline/bufferline.vim
+++ b/autoload/lightline/bufferline.vim
@@ -4,12 +4,8 @@
 
 scriptencoding utf-8
 
-if exists('g:loaded_lightline_bufferline')
-  finish
-endif
-let g:loaded_lightline_bufferline = 1
-
 let s:filename_modifier = get(g:, 'lightline#bufferline#filename_modifier', ':.')
+let s:min_buffer_count  = get(g:, 'lightline#bufferline#min_buffer_count', 0)
 let s:number_map        = get(g:, 'lightline#bufferline#number_map', {})
 let s:shorten_path      = get(g:, 'lightline#bufferline#shorten_path', 1)
 let s:show_number       = get(g:, 'lightline#bufferline#show_number', 0)
@@ -181,6 +177,28 @@ function! s:is_read_only(buffer)
     let l:modifiable = getbufvar(a:buffer, '&modifiable')
     let l:readonly = getbufvar(a:buffer, '&readonly')
     return (l:readonly || !l:modifiable) && getbufvar(a:buffer, '&filetype') !=# 'help'
+endfunction
+
+function! s:auto_tabline(buffer_count) abort
+  if a:buffer_count >= s:min_buffer_count
+    if &showtabline != 2 && &lines > 3
+      set showtabline=2
+    endif
+  else
+    if &showtabline != 0
+      set showtabline=0
+    endif
+  endif
+endfunction
+
+function! lightline#bufferline#init()
+  augroup lightline_bufferline
+    autocmd!
+    if s:min_buffer_count > 0
+      autocmd BufEnter  * call <SID>auto_tabline(len(<SID>filtered_buffers()))
+      autocmd BufUnload * call <SID>auto_tabline(len(<SID>filtered_buffers()) - 1)
+    endif
+  augroup END
 endfunction
 
 function! lightline#bufferline#buffers()

--- a/plugin/bufferline.vim
+++ b/plugin/bufferline.vim
@@ -1,0 +1,10 @@
+" Plugin:      https://github.com/mgee/lightline-bufferline
+" Description: A lightweight bufferline for the lightline vim plugin.
+" Maintainer:  Markus Engelbrecht <https://github.com/mgee>
+
+if exists('g:loaded_lightline_bufferline')
+  finish
+endif
+let g:loaded_lightline_bufferline = 1
+
+call lightline#bufferline#init()


### PR DESCRIPTION
A new configuration value - `g:lightline#bufferline#min_buffer_count` -
controls this behavior. When set to a positive value, it represents the
minimum number of buffers needed to automatically show the tabline; the
tabline is hidden when the buffer count is less. When set to 0 (the
default), the automatic tabline behavior is disabled.

This change requires the introduction of a "plugin" script in order to
trigger the initialization of a new 'lightline_bufferline' autocommand
group. This unfortunately partially defeats the purpose of the autoload
script, but I wanted to introduce the minimum number of changes here.

The code could be reorganized to be more autoload-friendly by defining
only functions in the autoload script and moving all configuration and
mappings to the plugin script, but that can be done in future changes.