### PR TITLE
Add character assignment to specific buffer numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,11 +75,27 @@ Valid values are:
 - `2`: Ordinal number (buffers are numbered from _1_ to _n_ sequentially)
 - `3`: Both buffer number and ordinal number next to each other
 
-For ordinal number in option `2` and `3` the number map `g:lightline#bufferline#number_map` is used as described below.
+For ordinal number in option `2` and `3` number maps `g:lightline#bufferline#number_map` and `g:lightline#bufferline#composed_number_map` are used as described below.
+
+##### `g:lightline#bufferline#composed_number_map`
+
+Dictionary mapping ordinal numbers to their alternative character representations. Default is `{}`.
+
+For example, to use parenthized unicode numbers taken from [Enclosed Alphanumerics Unicode block](https://unicode.org/charts/nameslist/c_2460.html):
+
+```viml
+let g:lightline#bufferline#composed_number_map = {
+\ 1:  '⑴ ', 2:  '⑵ ', 3:  '⑶ ', 4:  '⑷ ', 5:  '⑸ ',
+\ 6:  '⑹ ', 7:  '⑺ ', 8:  '⑻ ', 9:  '⑼ ', 10: '⑽ ',
+\ 11: '⑾ ', 12: '⑿ ', 13: '⒀ ', 14: '⒁ ', 15: '⒂ ',
+\ 16: '⒃ ', 17: '⒄ ', 18: '⒅ ', 19: '⒆ ', 20: '⒇ '}
+```
+
+_Note: The option only applies when `g:lightline#bufferline#show_number` is set to `2` or `3`._
 
 ##### `g:lightline#bufferline#number_map`
 
-Dictionary mapping ordinal numbers (0-9) to their alternate character representations. Default is `{}`.
+Fallback dictionary mapping digits (0-9) which are used in ordinal number composing if the number is not mapped in `g:lightline#bufferline#composed_number_map`. Default is `{}`.
 
 For example, to use unicode superscript numerals:
 

--- a/autoload/lightline/bufferline.vim
+++ b/autoload/lightline/bufferline.vim
@@ -4,25 +4,26 @@
 
 scriptencoding utf-8
 
-let s:filename_modifier = get(g:, 'lightline#bufferline#filename_modifier', ':.')
-let s:min_buffer_count  = get(g:, 'lightline#bufferline#min_buffer_count', 0)
-let s:number_map        = get(g:, 'lightline#bufferline#number_map', {})
-let s:shorten_path      = get(g:, 'lightline#bufferline#shorten_path', 1)
-let s:show_number       = get(g:, 'lightline#bufferline#show_number', 0)
-let s:number_separator  = get(g:, 'lightline#bufferline#number_separator', ' ')
-let s:unnamed           = get(g:, 'lightline#bufferline#unnamed', '*')
-let s:reverse_buffers   = get(g:, 'lightline#bufferline#reverse_buffers', 0)
-let s:right_aligned     = get(g:, 'lightline#bufferline#right_aligned', 0)
-let s:enable_devicons   = get(g:, 'lightline#bufferline#enable_devicons', 0)
-let s:unicode_symbols   = get(g:, 'lightline#bufferline#unicode_symbols', 0)
+let s:filename_modifier   = get(g:, 'lightline#bufferline#filename_modifier', ':.')
+let s:min_buffer_count    = get(g:, 'lightline#bufferline#min_buffer_count', 0)
+let s:number_map          = get(g:, 'lightline#bufferline#number_map', {})
+let s:composed_number_map = get(g:, 'lightline#bufferline#composed_number_map', {})
+let s:shorten_path        = get(g:, 'lightline#bufferline#shorten_path', 1)
+let s:show_number         = get(g:, 'lightline#bufferline#show_number', 0)
+let s:number_separator    = get(g:, 'lightline#bufferline#number_separator', ' ')
+let s:unnamed             = get(g:, 'lightline#bufferline#unnamed', '*')
+let s:reverse_buffers     = get(g:, 'lightline#bufferline#reverse_buffers', 0)
+let s:right_aligned       = get(g:, 'lightline#bufferline#right_aligned', 0)
+let s:enable_devicons     = get(g:, 'lightline#bufferline#enable_devicons', 0)
+let s:unicode_symbols     = get(g:, 'lightline#bufferline#unicode_symbols', 0)
 if s:unicode_symbols == 0
-  let s:modified        = get(g:, 'lightline#bufferline#modified', ' +')
-  let s:read_only       = get(g:, 'lightline#bufferline#read_only', ' -')
-  let s:more_buffers    = get(g:, 'lightline#bufferline#more_buffers', '...')
+  let s:modified          = get(g:, 'lightline#bufferline#modified', ' +')
+  let s:read_only         = get(g:, 'lightline#bufferline#read_only', ' -')
+  let s:more_buffers      = get(g:, 'lightline#bufferline#more_buffers', '...')
 else
-  let s:modified        = get(g:, 'lightline#bufferline#modified', ' ✎')
-  let s:read_only       = get(g:, 'lightline#bufferline#read_only', ' ')
-  let s:more_buffers    = get(g:, 'lightline#bufferline#more_buffers', '…')
+  let s:modified          = get(g:, 'lightline#bufferline#modified', ' ✎')
+  let s:read_only         = get(g:, 'lightline#bufferline#read_only', ' ')
+  let s:more_buffers      = get(g:, 'lightline#bufferline#more_buffers', '…')
 endif
 let s:more_buffers_width = len(s:more_buffers) + 2
 
@@ -57,11 +58,13 @@ endfunction
 
 function! s:get_from_number_map(i)
   let l:number = a:i
-  let l:result = ''
-  for i in range(1, strlen(l:number))
-    let l:result = get(s:number_map, l:number % 10, l:number % 10) . l:result
-    let l:number = l:number / 10
-  endfor
+  let l:result = get(s:composed_number_map, l:number, '')
+  if l:result == ""
+    for i in range(1, strlen(l:number))
+      let l:result = get(s:number_map, l:number % 10, l:number % 10) . l:result
+      let l:number = l:number / 10
+    endfor
+  endif
   return l:result
 endfunction
 


### PR DESCRIPTION
Added `g:lightline#bufferline#composed_number_map` map which you can use to assign specific characters to specific numbers without worrying that once buffer number reach 10, digit composing will make it ugly. You can even assign alphabet characters if you're into it. Example of what you can use if this PR gets merged: http://www.alanwood.net/unicode/enclosed_alphanumerics.html

![2020-01-03_22-55](https://user-images.githubusercontent.com/35058624/71746965-782a8c00-2e7f-11ea-97f0-fc57ffaa95bf.png)

If I need to rephrase something in README or change variable name, I can easily do that.
If my PR does not suit this extension, this is fine as well, I'll just use my forked version.