### PR TITLE
Add new number style

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,9 @@ Valid values are:
 - `1`: Buffer number as shown by the `:ls` command
 - `2`: Ordinal number (buffers are numbered from _1_ to _n_ sequentially)
 - `3`: Both buffer number and ordinal number next to each other
+- `4`: Both buffer number and ordinal number next to each other, where the oridinal number is shown before buffer number
 
-For ordinal number in option `2` and `3` number maps `g:lightline#bufferline#number_map` and `g:lightline#bufferline#composed_number_map` are used as described below.
+For ordinal number in option `2`, `3` and `4`, number maps `g:lightline#bufferline#number_map` and `g:lightline#bufferline#composed_number_map` are used as described below.
 
 ##### `g:lightline#bufferline#composed_number_map`
 
@@ -118,6 +119,10 @@ _Note: The option only applies when `g:lightline#bufferline#show_number` is set 
 ##### `g:lightline#bufferline#number_separator`
 
 Defines the string which is used to separate the buffer number (if enabled) and the buffer name. Default is `' '`.
+
+#### `g:lightline#bufferline#ordinal_separator`
+
+Defines the string which is used to separate the buffer number and the oridinal number. Default is `''`.
 
 ##### `g:lightline#bufferline#unnamed`
 

--- a/autoload/lightline/bufferline.vim
+++ b/autoload/lightline/bufferline.vim
@@ -11,6 +11,7 @@ let s:composed_number_map = get(g:, 'lightline#bufferline#composed_number_map', 
 let s:shorten_path        = get(g:, 'lightline#bufferline#shorten_path', 1)
 let s:show_number         = get(g:, 'lightline#bufferline#show_number', 0)
 let s:number_separator    = get(g:, 'lightline#bufferline#number_separator', ' ')
+let s:ordinal_separator   = get(g:, 'lightline#bufferline#ordinal_separator', '')
 let s:unnamed             = get(g:, 'lightline#bufferline#unnamed', '*')
 let s:reverse_buffers     = get(g:, 'lightline#bufferline#reverse_buffers', 0)
 let s:right_aligned       = get(g:, 'lightline#bufferline#right_aligned', 0)
@@ -51,7 +52,9 @@ function! s:get_buffer_name(i, buffer)
   elseif s:show_number == 2
     let l:name = s:get_from_number_map(a:i + 1). s:number_separator . l:name
   elseif s:show_number == 3
-    let l:name = a:buffer . s:get_from_number_map(a:i + 1) . s:number_separator . l:name
+    let l:name = a:buffer . s:ordinal_separator . s:get_from_number_map(a:i + 1) . s:number_separator . l:name
+  elseif s:show_number == 4
+    let l:name = s:get_from_number_map(a:i + 1) . s:ordinal_separator . a:buffer . s:number_separator . l:name
   endif
   return substitute(l:name, '%', '%%', 'g')
 endfunction


### PR DESCRIPTION
1. Add an option `4` for `g:lightline#bufferline#show_number` to enable ordinal number to be shown before the buffer number.

2. Add a new option `g:lightline#bufferline#ordinal_separator` to define the separator between the buffer number and the ordinal number.