### PR TITLE
Enable clickable buffers under Neovim

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,14 @@ Default is `0` (buffers are not reversed).
 If the bufferline is used in the `right` component of the tabline this should be set to `1` to ensure the correct order of the buffers.
 Default is `0`.
 
+##### `g:lightline#bufferline#clickable`
+
+If set to `1` the bufferline is clickable under Neovim versions with `tablineat` feature. To enable this feature, you must also set the bufferline component to be raw in your `vimrc`:
+
+```viml
+let g:lightline.component_raw = {'buffers': 1}
+```
+
 ## Mappings
 
 This plugin provides Plug mappings to switch to buffers using their ordinal number in the bufferline.

--- a/autoload/lightline/bufferline.vim
+++ b/autoload/lightline/bufferline.vim
@@ -32,7 +32,12 @@ else
   let s:component_is_raw  = 0
 endif
 let s:clickable           = has('tablineat') && s:component_is_raw ? get(g:, 'lightline#bufferline#clickable', 0) : 0
-let s:more_buffers_width = len(s:more_buffers) + 2
+if s:component_is_raw
+  let s:more_buffers = ' ' . s:more_buffers . ' '
+  let s:more_buffers_width = len(s:more_buffers)
+else
+  let s:more_buffers_width = len(s:more_buffers) + 2
+endif
 
 function! lightline#bufferline#_click_handler(minwid, clicks, btn, modifiers)
   call s:goto_nth_buffer(a:minwid)

--- a/autoload/lightline/bufferline.vim
+++ b/autoload/lightline/bufferline.vim
@@ -26,7 +26,17 @@ else
   let s:read_only         = get(g:, 'lightline#bufferline#read_only', ' ')
   let s:more_buffers      = get(g:, 'lightline#bufferline#more_buffers', '…')
 endif
+if exists('g:lightline.component_raw.buffers')
+  let s:component_is_raw  = g:lightline.component_raw.buffers
+else
+  let s:component_is_raw  = 0
+endif
+let s:clickable           = has('tablineat') && s:component_is_raw ? get(g:, 'lightline#bufferline#clickable', 0) : 0
 let s:more_buffers_width = len(s:more_buffers) + 2
+
+function! lightline#bufferline#_click_handler(minwid, clicks, btn, modifiers)
+  call s:goto_nth_buffer(a:minwid)
+endfunction
 
 function! s:get_buffer_name(i, buffer)
   let l:name = bufname(a:buffer)
@@ -56,7 +66,15 @@ function! s:get_buffer_name(i, buffer)
   elseif s:show_number == 4
     let l:name = s:get_from_number_map(a:i + 1) . s:ordinal_separator . a:buffer . s:number_separator . l:name
   endif
-  return substitute(l:name, '%', '%%', 'g')
+  let l:name = substitute(l:name, '%', '%%', 'g')
+  if s:component_is_raw
+    let l:name = ' ' . l:name . ' '
+  endif
+  if s:clickable
+    return '%' . string(a:i) . '@lightline#bufferline#_click_handler@' . l:name . '%X'
+  else
+    return l:name
+  endif
 endfunction
 
 function! s:get_from_number_map(i)

--- a/autoload/lightline/bufferline.vim
+++ b/autoload/lightline/bufferline.vim
@@ -71,14 +71,15 @@ function! s:get_buffer_name(i, buffer)
   elseif s:show_number == 4
     let l:name = s:get_from_number_map(a:i + 1) . s:ordinal_separator . a:buffer . s:number_separator . l:name
   endif
+  let l:len = len(l:name)
   let l:name = substitute(l:name, '%', '%%', 'g')
   if s:component_is_raw
     let l:name = ' ' . l:name . ' '
   endif
   if s:clickable
-    return '%' . string(a:i) . '@lightline#bufferline#_click_handler@' . l:name . '%X'
+    return ['%' . string(a:i) . '@lightline#bufferline#_click_handler@' . l:name . '%X', l:len]
   else
-    return l:name
+    return [l:name, l:len]
   endif
 endfunction
 
@@ -115,14 +116,13 @@ endfunction
 
 function! s:get_buffer_names(buffers, from, to)
   let l:names = []
+  let l:lengths = []
   for l:i in range(a:from, a:to - 1)
-    call add(l:names, s:get_buffer_name(l:i, a:buffers[l:i]))
+    let [l:name, l:len] = s:get_buffer_name(l:i, a:buffers[l:i])
+    call add(l:names, l:name)
+    call add(l:lengths, l:len + 4)
   endfor
-  return l:names
-endfunction
-
-function! s:get_buffer_lengths(list)
-  return map(copy(a:list), 'len(v:val) + 4')
+  return [l:names, l:lengths]
 endfunction
 
 function! s:sum(list)
@@ -147,37 +147,38 @@ function! s:fit_lengths(list, available)
 endfunction
 
 function! s:select_buffers(before, current, after)
-  let [l:before_lengths, l:after_lengths] = [s:get_buffer_lengths(a:before), s:get_buffer_lengths(a:after)]
+  let [l:before_names, l:current_names, l:after_names] = [a:before[0], a:current[0], a:after[0]]
+  let [l:before_lengths, l:current_lengths, l:after_lengths] = [a:before[1], a:current[1], a:after[1]]
 
   " The current buffer is always displayed
-  let l:width = &columns - s:get_buffer_lengths(a:current[:0])[0]
+  let l:width = &columns - l:current_lengths[:0][0]
 
   " Display all buffers if there is enough space to display them
   if s:sum(l:before_lengths) + s:sum(l:after_lengths) <= l:width
-    return [a:before, a:current, a:after]
+    return [l:before_names, l:current_names, l:after_names]
   endif
 
   " Try to fit as many buffers as possible
-  let [l:before, l:current, l:after] = s:select_fitting_buffers(a:before, a:current, a:after, l:before_lengths, l:after_lengths, l:width)
+  let [l:before, l:current, l:after] = s:select_fitting_buffers(l:before_names, l:current_names, l:after_names, l:before_lengths, l:after_lengths, l:width)
 
   " See on which side buffers did not fit
-  let l:more_before = len(a:before) > len(l:before)
-  let l:more_after = len(a:after) > len(l:after)
+  let l:more_before = len(l:before_names) > len(l:before)
+  let l:more_after = len(l:after_names) > len(l:after)
 
   if l:more_before && l:more_after
     " Buffers on both sides don't fit. Recompute, but account for s:more_buffers to be visible on both sides
-    let [l:before, l:current, l:after] = s:select_fitting_buffers(a:before, a:current, a:after, l:before_lengths, l:after_lengths, l:width - s:more_buffers_width*2)
+    let [l:before, l:current, l:after] = s:select_fitting_buffers(l:before_names, l:current_names, l:after_names, l:before_lengths, l:after_lengths, l:width - s:more_buffers_width*2)
     let l:before = [s:more_buffers] + l:before
     let l:after += [s:more_buffers]
   elseif l:more_before || l:more_after
     " Buffers on one side don't fit. Recompute, but account for s:more_buffers to be visible on that side
-    let [l:before, l:current, l:after] = s:select_fitting_buffers(a:before, a:current, a:after, l:before_lengths, l:after_lengths, l:width - s:more_buffers_width)
+    let [l:before, l:current, l:after] = s:select_fitting_buffers(l:before_names, l:current_names, l:after_names, l:before_lengths, l:after_lengths, l:width - s:more_buffers_width)
     " With s:more_buffers visible it is possible that buffers on another side don't fit anymore
-    let l:more_before = len(a:before) > len(l:before)
-    let l:more_after = len(a:after) > len(l:after)
+    let l:more_before = len(l:before_names) > len(l:before)
+    let l:more_after = len(l:after_names) > len(l:after)
     if l:more_before && l:more_after
       " Indeed, buffers on both sides don't fit now. Recompute, but account for s:more_buffers to be visible on both sides
-      let [l:before, l:current, l:after] = s:select_fitting_buffers(a:before, a:current, a:after, l:before_lengths, l:after_lengths, l:width - s:more_buffers_width*2)
+      let [l:before, l:current, l:after] = s:select_fitting_buffers(l:before_names, l:current_names, l:after_names, l:before_lengths, l:after_lengths, l:width - s:more_buffers_width*2)
       " Now add s:more_buffers on both sides
       let l:before = [s:more_buffers] + l:before
       let l:after += [s:more_buffers]
@@ -257,7 +258,7 @@ function! lightline#bufferline#buffers()
   let l:buffers = s:filtered_buffers()
   let l:current_index = index(l:buffers, bufnr('%'))
   if l:current_index == -1
-    return [s:get_buffer_names(l:buffers, 0, len(l:buffers)), [], []]
+    return [s:get_buffer_names(l:buffers, 0, len(l:buffers))[0], [], []]
   endif
   let l:before = s:get_buffer_names(l:buffers, 0, l:current_index)
   let l:current = s:get_buffer_names(l:buffers, l:current_index, l:current_index + 1)


### PR DESCRIPTION
1. Make buffer labels clickable by using the `tablineat` feature.
2. Add a new option `g:lightline#bufferline#clickable` to turn on/off this feature. The default value is `0`.