### PR TITLE
Implement g:lightline#bufferline#show_basedir

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ Valid values are:
 
 For ordinal number in option `2`, `3` and `4`, number maps `g:lightline#bufferline#number_map` and `g:lightline#bufferline#composed_number_map` are used as described below.
 
+##### `g:lightline#bufferline#show_basedir`
+
+Defines whether to add the buffer its base directory to the buffer name. Default is `0`.
+
 ##### `g:lightline#bufferline#composed_number_map`
 
 Dictionary mapping ordinal numbers to their alternative character representations. Default is `{}`.

--- a/autoload/lightline/bufferline.vim
+++ b/autoload/lightline/bufferline.vim
@@ -63,7 +63,6 @@ function! s:get_buffer_name(i, buffer)
   if getbufvar(a:buffer, '&mod')
     let l:name .= s:modified
   endif
-  echo l:name
   if s:show_basedir == 1 && bufname(a:buffer) !=# ''
     let l:name = fnamemodify(bufname(a:buffer), ':p:h:t') . '/' . l:name
   end

--- a/autoload/lightline/bufferline.vim
+++ b/autoload/lightline/bufferline.vim
@@ -10,6 +10,7 @@ let s:number_map          = get(g:, 'lightline#bufferline#number_map', {})
 let s:composed_number_map = get(g:, 'lightline#bufferline#composed_number_map', {})
 let s:shorten_path        = get(g:, 'lightline#bufferline#shorten_path', 1)
 let s:show_number         = get(g:, 'lightline#bufferline#show_number', 0)
+let s:show_basedir        = get(g:, 'lightline#bufferline#show_basedir', 0)
 let s:number_separator    = get(g:, 'lightline#bufferline#number_separator', ' ')
 let s:ordinal_separator   = get(g:, 'lightline#bufferline#ordinal_separator', '')
 let s:unnamed             = get(g:, 'lightline#bufferline#unnamed', '*')
@@ -62,6 +63,10 @@ function! s:get_buffer_name(i, buffer)
   if getbufvar(a:buffer, '&mod')
     let l:name .= s:modified
   endif
+  echo l:name
+  if s:show_basedir == 1 && bufname(a:buffer) !=# ''
+    let l:name = fnamemodify(bufname(a:buffer), ':p:h:t') . '/' . l:name
+  end
   if s:show_number == 1
     let l:name = a:buffer . s:number_separator . l:name
   elseif s:show_number == 2


### PR DESCRIPTION
Since I do quite a lot of front-end development such as React the general structure we mostly use is `components/<component-name>/index.jsx` and when I have multiple files open they all show `index.js` because I've set `let g:lightline#bufferline#filename_modifier = ':t'`. I always like to have the basedir of the current buffer with it so I know which component I'm working in. I've had colleagues at several companies who also preferred this setup.

Given
```
/Users/<name>/projects/<project-name>/index.js
```

Using the following settings: 

```vim
let g:lightline#bufferline#filename_modifier = ':t'
let g:lightline#bufferline#show_basedir = 1
```

It will result in: `<project-name>/index.js`.

Let me know if I'm missing anything that requires to be updated in the documentation parts before the PR is valid. Thanks in advance.