### PR TITLE
Added delete tab by ordinal number option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,16 +200,16 @@ nmap <Leader>0 <Plug>lightline#bufferline#go(10)
 Additionally you can use the following e.g. to delete buffers by their ordinal number.
 
 ```viml
-nmap <Leader>1 <Plug>lightline#bufferline#delete(1)
-nmap <Leader>2 <Plug>lightline#bufferline#delete(2)
-nmap <Leader>3 <Plug>lightline#bufferline#delete(3)
-nmap <Leader>4 <Plug>lightline#bufferline#delete(4)
-nmap <Leader>5 <Plug>lightline#bufferline#delete(5)
-nmap <Leader>6 <Plug>lightline#bufferline#delete(6)
-nmap <Leader>7 <Plug>lightline#bufferline#delete(7)
-nmap <Leader>8 <Plug>lightline#bufferline#delete(8)
-nmap <Leader>9 <Plug>lightline#bufferline#delete(9)
-nmap <Leader>0 <Plug>lightline#bufferline#delete(10)
+nmap <Leader>c1 <Plug>lightline#bufferline#delete(1)
+nmap <Leader>c2 <Plug>lightline#bufferline#delete(2)
+nmap <Leader>c3 <Plug>lightline#bufferline#delete(3)
+nmap <Leader>c4 <Plug>lightline#bufferline#delete(4)
+nmap <Leader>c5 <Plug>lightline#bufferline#delete(5)
+nmap <Leader>c6 <Plug>lightline#bufferline#delete(6)
+nmap <Leader>c7 <Plug>lightline#bufferline#delete(7)
+nmap <Leader>c8 <Plug>lightline#bufferline#delete(8)
+nmap <Leader>c9 <Plug>lightline#bufferline#delete(9)
+nmap <Leader>c0 <Plug>lightline#bufferline#delete(10)
 ```
 
 ## Example

--- a/README.md
+++ b/README.md
@@ -197,6 +197,21 @@ nmap <Leader>9 <Plug>lightline#bufferline#go(9)
 nmap <Leader>0 <Plug>lightline#bufferline#go(10)
 ```
 
+Additionally you can use the following e.g. to delete buffers by their ordinal number.
+
+```viml
+nmap <Leader>1 <Plug>lightline#bufferline#delete(1)
+nmap <Leader>2 <Plug>lightline#bufferline#delete(2)
+nmap <Leader>3 <Plug>lightline#bufferline#delete(3)
+nmap <Leader>4 <Plug>lightline#bufferline#delete(4)
+nmap <Leader>5 <Plug>lightline#bufferline#delete(5)
+nmap <Leader>6 <Plug>lightline#bufferline#delete(6)
+nmap <Leader>7 <Plug>lightline#bufferline#delete(7)
+nmap <Leader>8 <Plug>lightline#bufferline#delete(8)
+nmap <Leader>9 <Plug>lightline#bufferline#delete(9)
+nmap <Leader>0 <Plug>lightline#bufferline#delete(10)
+```
+
 ## Example
 
 The following minimal example adds the bufferline to the lightline tabline and demonstrates a few custom bufferline options:

--- a/autoload/lightline/bufferline.vim
+++ b/autoload/lightline/bufferline.vim
@@ -114,6 +114,13 @@ function! s:goto_nth_buffer(n)
   endif
 endfunction
 
+function! s:delete_nth_buffer(n)
+  let l:buffers = s:filtered_buffers()
+  if a:n < len(l:buffers)
+    execute 'bd' . l:buffers[a:n]
+  endif
+endfunction
+
 function! s:get_buffer_names(buffers, from, to)
   let l:names = []
   let l:lengths = []
@@ -280,3 +287,14 @@ noremap <silent> <Plug>lightline#bufferline#go(7)  :call <SID>goto_nth_buffer(6)
 noremap <silent> <Plug>lightline#bufferline#go(8)  :call <SID>goto_nth_buffer(7)<CR>
 noremap <silent> <Plug>lightline#bufferline#go(9)  :call <SID>goto_nth_buffer(8)<CR>
 noremap <silent> <Plug>lightline#bufferline#go(10) :call <SID>goto_nth_buffer(9)<CR>
+
+noremap <silent> <Plug>lightline#bufferline#delete(1)  :call <SID>delete_nth_buffer(0)<CR>
+noremap <silent> <Plug>lightline#bufferline#delete(2)  :call <SID>delete_nth_buffer(1)<CR>
+noremap <silent> <Plug>lightline#bufferline#delete(3)  :call <SID>delete_nth_buffer(2)<CR>
+noremap <silent> <Plug>lightline#bufferline#delete(4)  :call <SID>delete_nth_buffer(3)<CR>
+noremap <silent> <Plug>lightline#bufferline#delete(5)  :call <SID>delete_nth_buffer(4)<CR>
+noremap <silent> <Plug>lightline#bufferline#delete(6)  :call <SID>delete_nth_buffer(5)<CR>
+noremap <silent> <Plug>lightline#bufferline#delete(7)  :call <SID>delete_nth_buffer(6)<CR>
+noremap <silent> <Plug>lightline#bufferline#delete(8)  :call <SID>delete_nth_buffer(7)<CR>
+noremap <silent> <Plug>lightline#bufferline#delete(9)  :call <SID>delete_nth_buffer(8)<CR>
+noremap <silent> <Plug>lightline#bufferline#delete(10) :call <SID>delete_nth_buffer(9)<CR>


### PR DESCRIPTION
This PR adds the ability to close the buffers by its ordinal number so you can do something like this:

```vimrc
nmap <Leader>c1 <Plug>lightline#bufferline#delete(1)
```

Originally I thought about exposing the `filtered_buffers` variable to the global scope but I decided against it. I think expanding the existing select buffer by its ordinal number to deleting them by ordinal number is good enough.