### PR TITLE
Added an option for positioning icons (left or right)

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,8 +157,7 @@ Default is `0`.
 ##### `g:lightline#bufferline#icon_position`
 
 If set to `right`, filetype icons are displayed on the right side of the file name.
-If `left` or omitted, it will be displayed on the left side.
-Default is `left`.
+If `left` or omitted, it will be displayed on the left side. Default is `left`.
 
 ##### `g:lightline#bufferline#unicode_symbols`
 

--- a/README.md
+++ b/README.md
@@ -173,6 +173,11 @@ Default is `0` (no auto-show behavior).
 If enabled the buffers will be displayed in a reversed order.
 Default is `0` (buffers are not reversed).
 
+##### `g:lightline#bufferline#reverse_buffer_icons`
+
+If set to `1`, buffer icons are displayed on the right side of the file name.
+If `0`, it will be displayed on the left side. Default is `0`.
+
 ##### `g:lightline#bufferline#right_aligned`
 
 If the bufferline is used in the `right` component of the tabline this should be set to `1` to ensure the correct order of the buffers.
@@ -229,6 +234,7 @@ This plugin provides some public functions to operate with buffers using their o
 
 This function switches to the buffer with the ordinal number specified by parameter `n`.
 To switch to the first buffer using a mapping you can use the function like this:
+
 ```viml
 nmap <Leader>1 :call lightline#bufferline#go(1)<CR>
 ```
@@ -237,6 +243,7 @@ nmap <Leader>1 :call lightline#bufferline#go(1)<CR>
 
 This function deletes the buffer with the ordinal number specified by parameter `n`.
 To delete the first buffer using a mapping you can use the function like this:
+
 ```viml
 nmap <D-1> :call lightline#bufferline#delete(1)<CR>
 ```

--- a/README.md
+++ b/README.md
@@ -157,7 +157,8 @@ Default is `0`.
 ##### `g:lightline#bufferline#icon_position`
 
 If set to `right`, filetype icons are displayed on the right side of the file name.
-If `left` or omitted, it will be displayed on the left side. Default is `left`.
+If `left` or omitted, it will be displayed on the left side.
+Default is `left`.
 
 ##### `g:lightline#bufferline#unicode_symbols`
 

--- a/README.md
+++ b/README.md
@@ -154,6 +154,11 @@ Default is `0`.
 Enables the usage of [nerdfont.vim](https://github.com/lambdalisue/nerdfont.vim) to display a filetype icon for the buffer.
 Default is `0`.
 
+##### `g:lightline#bufferline#icon_position`
+
+If set to `right`, filetype icons are displayed on the right side of the file name.
+If `left` or omitted, it will be displayed on the left side. Default is `left`.
+
 ##### `g:lightline#bufferline#unicode_symbols`
 
 Use unicode symbols for modified and read-only buffers as well as the more buffers indicator. Default is `0`.
@@ -172,11 +177,6 @@ Default is `0` (no auto-show behavior).
 
 If enabled the buffers will be displayed in a reversed order.
 Default is `0` (buffers are not reversed).
-
-##### `g:lightline#bufferline#reverse_buffer_icons`
-
-If set to `1`, buffer icons are displayed on the right side of the file name.
-If `0`, it will be displayed on the left side. Default is `0`.
 
 ##### `g:lightline#bufferline#right_aligned`
 

--- a/autoload/lightline/bufferline.vim
+++ b/autoload/lightline/bufferline.vim
@@ -4,38 +4,38 @@
 
 scriptencoding utf-8
 
-let s:dirsep              = fnamemodify(getcwd(),':p')[-1:]
-let s:filename_modifier   = get(g:, 'lightline#bufferline#filename_modifier', ':.')
-let s:min_buffer_count    = get(g:, 'lightline#bufferline#min_buffer_count', 0)
-let s:number_map          = get(g:, 'lightline#bufferline#number_map', {})
-let s:composed_number_map = get(g:, 'lightline#bufferline#composed_number_map', {})
-let s:shorten_path        = get(g:, 'lightline#bufferline#shorten_path', 1)
-let s:smart_path          = get(g:, 'lightline#bufferline#smart_path', 1)
-let s:show_number         = get(g:, 'lightline#bufferline#show_number', 0)
-let s:number_separator    = get(g:, 'lightline#bufferline#number_separator', ' ')
-let s:ordinal_separator   = get(g:, 'lightline#bufferline#ordinal_separator', '')
-let s:unnamed             = get(g:, 'lightline#bufferline#unnamed', '*')
-let s:reverse_buffers     = get(g:, 'lightline#bufferline#reverse_buffers', 0)
-let s:reverse_buffer_icons     = get(g:, 'lightline#bufferline#reverse_buffer_icon', 0)
-let s:right_aligned       = get(g:, 'lightline#bufferline#right_aligned', 0)
-let s:enable_devicons     = get(g:, 'lightline#bufferline#enable_devicons', 0)
-let s:enable_nerdfont     = get(g:, 'lightline#bufferline#enable_nerdfont', 0)
-let s:unicode_symbols     = get(g:, 'lightline#bufferline#unicode_symbols', 0)
+let s:dirsep                = fnamemodify(getcwd(),':p')[-1:]
+let s:filename_modifier     = get(g:, 'lightline#bufferline#filename_modifier', ':.')
+let s:min_buffer_count      = get(g:, 'lightline#bufferline#min_buffer_count', 0)
+let s:number_map            = get(g:, 'lightline#bufferline#number_map', {})
+let s:composed_number_map   = get(g:, 'lightline#bufferline#composed_number_map', {})
+let s:shorten_path          = get(g:, 'lightline#bufferline#shorten_path', 1)
+let s:smart_path            = get(g:, 'lightline#bufferline#smart_path', 1)
+let s:show_number           = get(g:, 'lightline#bufferline#show_number', 0)
+let s:number_separator      = get(g:, 'lightline#bufferline#number_separator', ' ')
+let s:ordinal_separator     = get(g:, 'lightline#bufferline#ordinal_separator', '')
+let s:unnamed               = get(g:, 'lightline#bufferline#unnamed', '*')
+let s:reverse_buffers       = get(g:, 'lightline#bufferline#reverse_buffers', 0)
+let s:reverse_buffer_icons  = get(g:, 'lightline#bufferline#reverse_buffer_icons', 0)
+let s:right_aligned         = get(g:, 'lightline#bufferline#right_aligned', 0)
+let s:enable_devicons       = get(g:, 'lightline#bufferline#enable_devicons', 0)
+let s:enable_nerdfont       = get(g:, 'lightline#bufferline#enable_nerdfont', 0)
+let s:unicode_symbols       = get(g:, 'lightline#bufferline#unicode_symbols', 0)
 if s:unicode_symbols == 0
-  let s:modified          = get(g:, 'lightline#bufferline#modified', ' +')
-  let s:read_only         = get(g:, 'lightline#bufferline#read_only', ' -')
-  let s:more_buffers      = get(g:, 'lightline#bufferline#more_buffers', '...')
+  let s:modified            = get(g:, 'lightline#bufferline#modified', ' +')
+  let s:read_only           = get(g:, 'lightline#bufferline#read_only', ' -')
+  let s:more_buffers        = get(g:, 'lightline#bufferline#more_buffers', '...')
 else
-  let s:modified          = get(g:, 'lightline#bufferline#modified', ' ✎')
-  let s:read_only         = get(g:, 'lightline#bufferline#read_only', ' ')
-  let s:more_buffers      = get(g:, 'lightline#bufferline#more_buffers', '…')
+  let s:modified            = get(g:, 'lightline#bufferline#modified', ' ✎')
+  let s:read_only           = get(g:, 'lightline#bufferline#read_only', ' ')
+  let s:more_buffers        = get(g:, 'lightline#bufferline#more_buffers', '…')
 endif
 if exists('g:lightline.component_raw.buffers')
-  let s:component_is_raw  = g:lightline.component_raw.buffers
+  let s:component_is_raw   = g:lightline.component_raw.buffers
 else
-  let s:component_is_raw  = 0
+  let s:component_is_raw   = 0
 endif
-let s:clickable           = has('tablineat') && s:component_is_raw ? get(g:, 'lightline#bufferline#clickable', 0) : 0
+let s:clickable            = has('tablineat') && s:component_is_raw ? get(g:, 'lightline#bufferline#clickable', 0) : 0
 if s:component_is_raw
   let s:more_buffers = ' ' . s:more_buffers . ' '
   let s:more_buffers_width = len(s:more_buffers)
@@ -72,18 +72,31 @@ function! s:get_buffer_name(i, buffer, path)
       let l:name = pathshorten(l:name)
     endif
   endif
-  if exists('*WebDevIconsGetFileTypeSymbol') && s:enable_devicons == 1 && s:reverse_buffer_icons == 0
-    let l:name = WebDevIconsGetFileTypeSymbol(fnamemodify(bufname(a:buffer), ':t')) . ' ' . l:name
-  elseif s:reverse_buffer_icons == 1
-    let l:name = l:name . ' ' . WebDevIconsGetFileTypeSymbol(fnamemodify(bufname(a:buffer), ':t'))
-  elseif s:enable_devicons == 1 && has('nvim-0.5') && exists('g:nvim_web_devicons')
-    let l:name = v:lua._bufferline_get_icon(bufname(a:buffer)) . ' ' . l:name
-  elseif s:enable_nerdfont == 1
-    try
-      let l:name = nerdfont#find(fnamemodify(bufname(a:buffer), ':t'), 0) . ' ' . l:name
+
+  function! s:get_icon(buffer)
+    if s:enable_devicons == 1 && exists('*WebDevIconsGetFileTypeSymbol')
+      return WebDevIconsGetFileTypeSymbol(fnamemodify(bufname(a:buffer), ':t'))
+    endif
+
+    if s:enable_devicons == 1 && has('nvim-0.5') && exists('g:nvim_web_devicons')
+      return v:lua._bufferline_get_icon(bufname(a:buffer))
+    endif
+
+    if s:enable_nerdfont == 1
+      try
+        return nerdfont#find(fnamemodify(bufname(a:buffer), ':t'), 0)
       catch /^Vim\%((\a\+)\)\=:E117:/
-    endtry
+      endtry
+    endif
+
+    return ''
+  endfunction
+
+  let l:icon = s:get_icon(a:buffer)
+  if l:icon != ''
+    let l:name = s:reverse_buffer_icons == 0 ? (l:icon . ' ' . l:name) : (l:name . ' ' . l:icon)
   endif
+
   if s:is_read_only(a:buffer)
     let l:name .= s:read_only
   endif

--- a/autoload/lightline/bufferline.vim
+++ b/autoload/lightline/bufferline.vim
@@ -16,6 +16,7 @@ let s:number_separator    = get(g:, 'lightline#bufferline#number_separator', ' '
 let s:ordinal_separator   = get(g:, 'lightline#bufferline#ordinal_separator', '')
 let s:unnamed             = get(g:, 'lightline#bufferline#unnamed', '*')
 let s:reverse_buffers     = get(g:, 'lightline#bufferline#reverse_buffers', 0)
+let s:reverse_buffer_icons     = get(g:, 'lightline#bufferline#reverse_buffer_icon', 0)
 let s:right_aligned       = get(g:, 'lightline#bufferline#right_aligned', 0)
 let s:enable_devicons     = get(g:, 'lightline#bufferline#enable_devicons', 0)
 let s:enable_nerdfont     = get(g:, 'lightline#bufferline#enable_nerdfont', 0)
@@ -71,13 +72,13 @@ function! s:get_buffer_name(i, buffer, path)
       let l:name = pathshorten(l:name)
     endif
   endif
-  if s:enable_devicons == 1 && exists('*WebDevIconsGetFileTypeSymbol')
+  if exists('*WebDevIconsGetFileTypeSymbol') && (s:enable_devicons == 1 && s:reverse_buffer_icons == 0)
     let l:name = WebDevIconsGetFileTypeSymbol(fnamemodify(bufname(a:buffer), ':t')) . ' ' . l:name
-  elseif s:enable_devicons == 1 && has('nvim-0.5') && exists('g:nvim_web_devicons')
-    let l:name = v:lua._bufferline_get_icon(bufname(a:buffer)) . ' ' . l:name
+  elseif s:reverse_buffer_icons == 1
+    let l:name = l:name . ' ' . WebDevIconsGetFileTypeSymbol(fnamemodify(bufname(a:buffer), ':t'))
   elseif s:enable_nerdfont == 1
-    try
-      let l:name = nerdfont#find(fnamemodify(bufname(a:buffer), ':t'), 0) . ' ' . l:name
+  try
+    let l:name = nerdfont#find(fnamemodify(bufname(a:buffer), ':t'), 0) . ' ' . l:name
     catch /^Vim\%((\a\+)\)\=:E117:/
     endtry
   endif

--- a/autoload/lightline/bufferline.vim
+++ b/autoload/lightline/bufferline.vim
@@ -114,7 +114,7 @@ function! s:get_icon(buffer)
     return v:lua._bufferline_get_icon(bufname(a:buffer))
   endif
 
- if s:enable_nerdfont == 1
+  if s:enable_nerdfont == 1
     try
       return nerdfont#find(fnamemodify(bufname(a:buffer), ':t'), 0)
     catch /^Vim\%((\a\+)\)\=:E117:/

--- a/autoload/lightline/bufferline.vim
+++ b/autoload/lightline/bufferline.vim
@@ -72,14 +72,16 @@ function! s:get_buffer_name(i, buffer, path)
       let l:name = pathshorten(l:name)
     endif
   endif
-  if exists('*WebDevIconsGetFileTypeSymbol') && (s:enable_devicons == 1 && s:reverse_buffer_icons == 0)
+  if exists('*WebDevIconsGetFileTypeSymbol') && s:enable_devicons == 1 && s:reverse_buffer_icons == 0
     let l:name = WebDevIconsGetFileTypeSymbol(fnamemodify(bufname(a:buffer), ':t')) . ' ' . l:name
   elseif s:reverse_buffer_icons == 1
     let l:name = l:name . ' ' . WebDevIconsGetFileTypeSymbol(fnamemodify(bufname(a:buffer), ':t'))
+  elseif s:enable_devicons == 1 && has('nvim-0.5') && exists('g:nvim_web_devicons')
+    let l:name = v:lua._bufferline_get_icon(bufname(a:buffer)) . ' ' . l:name
   elseif s:enable_nerdfont == 1
-  try
-    let l:name = nerdfont#find(fnamemodify(bufname(a:buffer), ':t'), 0) . ' ' . l:name
-    catch /^Vim\%((\a\+)\)\=:E117:/
+    try
+      let l:name = nerdfont#find(fnamemodify(bufname(a:buffer), ':t'), 0) . ' ' . l:name
+      catch /^Vim\%((\a\+)\)\=:E117:/
     endtry
   endif
   if s:is_read_only(a:buffer)

--- a/autoload/lightline/bufferline.vim
+++ b/autoload/lightline/bufferline.vim
@@ -73,25 +73,6 @@ function! s:get_buffer_name(i, buffer, path)
     endif
   endif
 
-  function! s:get_icon(buffer)
-    if s:enable_devicons == 1 && exists('*WebDevIconsGetFileTypeSymbol')
-      return WebDevIconsGetFileTypeSymbol(fnamemodify(bufname(a:buffer), ':t'))
-    endif
-
-    if s:enable_devicons == 1 && has('nvim-0.5') && exists('g:nvim_web_devicons')
-      return v:lua._bufferline_get_icon(bufname(a:buffer))
-    endif
-
-    if s:enable_nerdfont == 1
-      try
-        return nerdfont#find(fnamemodify(bufname(a:buffer), ':t'), 0)
-      catch /^Vim\%((\a\+)\)\=:E117:/
-      endtry
-    endif
-
-    return ''
-  endfunction
-
   let l:icon = s:get_icon(a:buffer)
   if l:icon != ''
     let l:name = s:reverse_buffer_icons == 0 ? (l:icon . ' ' . l:name) : (l:name . ' ' . l:icon)
@@ -122,6 +103,25 @@ function! s:get_buffer_name(i, buffer, path)
   else
     return [l:name, l:len]
   endif
+endfunction
+
+function! s:get_icon(buffer)
+  if s:enable_devicons == 1 && exists('*WebDevIconsGetFileTypeSymbol')
+    return WebDevIconsGetFileTypeSymbol(fnamemodify(bufname(a:buffer), ':t'))
+  endif
+
+  if s:enable_devicons == 1 && has('nvim-0.5') && exists('g:nvim_web_devicons')
+    return v:lua._bufferline_get_icon(bufname(a:buffer))
+  endif
+
+  if s:enable_nerdfont == 1
+    try
+      return nerdfont#find(fnamemodify(bufname(a:buffer), ':t'), 0)
+    catch /^Vim\%((\a\+)\)\=:E117:/
+    endtry
+  endif
+
+  return ''
 endfunction
 
 function! s:get_from_number_map(i)

--- a/autoload/lightline/bufferline.vim
+++ b/autoload/lightline/bufferline.vim
@@ -4,38 +4,38 @@
 
 scriptencoding utf-8
 
-let s:dirsep                = fnamemodify(getcwd(),':p')[-1:]
-let s:filename_modifier     = get(g:, 'lightline#bufferline#filename_modifier', ':.')
-let s:min_buffer_count      = get(g:, 'lightline#bufferline#min_buffer_count', 0)
-let s:number_map            = get(g:, 'lightline#bufferline#number_map', {})
-let s:composed_number_map   = get(g:, 'lightline#bufferline#composed_number_map', {})
-let s:shorten_path          = get(g:, 'lightline#bufferline#shorten_path', 1)
-let s:smart_path            = get(g:, 'lightline#bufferline#smart_path', 1)
-let s:show_number           = get(g:, 'lightline#bufferline#show_number', 0)
-let s:number_separator      = get(g:, 'lightline#bufferline#number_separator', ' ')
-let s:ordinal_separator     = get(g:, 'lightline#bufferline#ordinal_separator', '')
-let s:unnamed               = get(g:, 'lightline#bufferline#unnamed', '*')
-let s:reverse_buffers       = get(g:, 'lightline#bufferline#reverse_buffers', 0)
-let s:reverse_buffer_icons  = get(g:, 'lightline#bufferline#reverse_buffer_icons', 0)
-let s:right_aligned         = get(g:, 'lightline#bufferline#right_aligned', 0)
-let s:enable_devicons       = get(g:, 'lightline#bufferline#enable_devicons', 0)
-let s:enable_nerdfont       = get(g:, 'lightline#bufferline#enable_nerdfont', 0)
-let s:unicode_symbols       = get(g:, 'lightline#bufferline#unicode_symbols', 0)
+let s:dirsep              = fnamemodify(getcwd(),':p')[-1:]
+let s:filename_modifier   = get(g:, 'lightline#bufferline#filename_modifier', ':.')
+let s:min_buffer_count    = get(g:, 'lightline#bufferline#min_buffer_count', 0)
+let s:number_map          = get(g:, 'lightline#bufferline#number_map', {})
+let s:composed_number_map = get(g:, 'lightline#bufferline#composed_number_map', {})
+let s:shorten_path        = get(g:, 'lightline#bufferline#shorten_path', 1)
+let s:smart_path          = get(g:, 'lightline#bufferline#smart_path', 1)
+let s:show_number         = get(g:, 'lightline#bufferline#show_number', 0)
+let s:number_separator    = get(g:, 'lightline#bufferline#number_separator', ' ')
+let s:ordinal_separator   = get(g:, 'lightline#bufferline#ordinal_separator', '')
+let s:unnamed             = get(g:, 'lightline#bufferline#unnamed', '*')
+let s:reverse_buffers     = get(g:, 'lightline#bufferline#reverse_buffers', 0)
+let s:right_aligned       = get(g:, 'lightline#bufferline#right_aligned', 0)
+let s:enable_devicons     = get(g:, 'lightline#bufferline#enable_devicons', 0)
+let s:enable_nerdfont     = get(g:, 'lightline#bufferline#enable_nerdfont', 0)
+let s:icon_position       = get(g:, 'lightline#bufferline#icon_position', 'left')
+let s:unicode_symbols     = get(g:, 'lightline#bufferline#unicode_symbols', 0)
 if s:unicode_symbols == 0
-  let s:modified            = get(g:, 'lightline#bufferline#modified', ' +')
-  let s:read_only           = get(g:, 'lightline#bufferline#read_only', ' -')
-  let s:more_buffers        = get(g:, 'lightline#bufferline#more_buffers', '...')
+  let s:modified          = get(g:, 'lightline#bufferline#modified', ' +')
+  let s:read_only         = get(g:, 'lightline#bufferline#read_only', ' -')
+  let s:more_buffers      = get(g:, 'lightline#bufferline#more_buffers', '...')
 else
-  let s:modified            = get(g:, 'lightline#bufferline#modified', ' ✎')
-  let s:read_only           = get(g:, 'lightline#bufferline#read_only', ' ')
-  let s:more_buffers        = get(g:, 'lightline#bufferline#more_buffers', '…')
+  let s:modified          = get(g:, 'lightline#bufferline#modified', ' ✎')
+  let s:read_only         = get(g:, 'lightline#bufferline#read_only', ' ')
+  let s:more_buffers      = get(g:, 'lightline#bufferline#more_buffers', '…')
 endif
 if exists('g:lightline.component_raw.buffers')
-  let s:component_is_raw   = g:lightline.component_raw.buffers
+  let s:component_is_raw  = g:lightline.component_raw.buffers
 else
-  let s:component_is_raw   = 0
+  let s:component_is_raw  = 0
 endif
-let s:clickable            = has('tablineat') && s:component_is_raw ? get(g:, 'lightline#bufferline#clickable', 0) : 0
+let s:clickable           = has('tablineat') && s:component_is_raw ? get(g:, 'lightline#bufferline#clickable', 0) : 0
 if s:component_is_raw
   let s:more_buffers = ' ' . s:more_buffers . ' '
   let s:more_buffers_width = len(s:more_buffers)
@@ -75,7 +75,7 @@ function! s:get_buffer_name(i, buffer, path)
 
   let l:icon = s:get_icon(a:buffer)
   if l:icon != ''
-    let l:name = s:reverse_buffer_icons == 0 ? (l:icon . ' ' . l:name) : (l:name . ' ' . l:icon)
+    let l:name = s:icon_position ==? 'right' ?  (l:name . ' ' . l:icon) : (l:icon . ' ' . l:name)
   endif
 
   if s:is_read_only(a:buffer)
@@ -114,7 +114,7 @@ function! s:get_icon(buffer)
     return v:lua._bufferline_get_icon(bufname(a:buffer))
   endif
 
-  if s:enable_nerdfont == 1
+ if s:enable_nerdfont == 1
     try
       return nerdfont#find(fnamemodify(bufname(a:buffer), ':t'), 0)
     catch /^Vim\%((\a\+)\)\=:E117:/


### PR DESCRIPTION
### Added an option for positioning icons (left or right)

![sample](https://user-images.githubusercontent.com/74660910/99662456-f11ddc80-2a6d-11eb-9b59-faac23812d9e.png)

`g:lightline#bufferline#reverse_buffer_icon`

If set to `1`, buffer icons are displayed on the right side of the file name. If `0`, it will be displayed on the left side. Default is `0`.