### PR TITLE
Fix disappearing bufferline when minimum buffer count is configured

### DIFF
--- a/autoload/lightline/bufferline.vim
+++ b/autoload/lightline/bufferline.vim
@@ -357,7 +357,7 @@ function! lightline#bufferline#init()
     autocmd!
     if s:min_buffer_count > 0
       autocmd BufEnter  * call <SID>auto_tabline(len(<SID>filtered_buffers()))
-      autocmd BufUnload * call <SID>auto_tabline(len(<SID>filtered_buffers()) - 1)
+      autocmd BufDelete * call <SID>auto_tabline(len(<SID>filtered_buffers()) - 1)
     endif
   augroup END
 endfunction


### PR DESCRIPTION
In some cases the bufferline was hidden although the minimum buffer count was reached.
This is caused by the BufUnload event which apparently happens too early for the autotabline feature.
The BufDelete event is emitted after the BufUnload event and reacting to this event instead fixes this.

Fixes #71.