### PR TITLE
feat: integrate nvim-web-devicons (part 2)

### DIFF
--- a/autoload/lightline/bufferline.vim
+++ b/autoload/lightline/bufferline.vim
@@ -98,26 +98,11 @@ function! s:get_buffer_name(i, buffer, path)
   endif
 endfunction
 
-if has('nvim-0.5') && exists('g:nvim_web_devicons')
-  lua <<EOF
-  function _G._bufferline_get_icon(path)
-   local filename = vim.api.nvim_eval("fnamemodify('"..path.."', ':t')")
-   local extension = vim.api.nvim_eval("fnamemodify('"..path.."', ':e')")
-   local icon, hl_group = require'nvim-web-devicons'.get_icon(filename, extension, { default = true })
-   if icon then
-     return icon
-   else
-     return ""
-   end
-  end
-EOF
-endif
-
 function! s:get_icon(buffer)
   if s:enable_devicons == 1 && exists('*WebDevIconsGetFileTypeSymbol')
     return WebDevIconsGetFileTypeSymbol(fnamemodify(bufname(a:buffer), ':t'))
   elseif s:enable_devicons == 1 && has('nvim-0.5') && exists('g:nvim_web_devicons')
-    return v:lua._bufferline_get_icon(bufname(a:buffer))
+    return luaeval("require('bufferline')._get_icon('" . bufname(a:buffer) . "')")
   endif
 
   if s:enable_nerdfont == 1

--- a/autoload/lightline/bufferline.vim
+++ b/autoload/lightline/bufferline.vim
@@ -98,9 +98,26 @@ function! s:get_buffer_name(i, buffer, path)
   endif
 endfunction
 
+if has('nvim-0.5') && exists('g:nvim_web_devicons')
+  lua <<EOF
+  function _G._bufferline_get_icon(path)
+   local filename = vim.api.nvim_eval("fnamemodify('"..path.."', ':t')")
+   local extension = vim.api.nvim_eval("fnamemodify('"..path.."', ':e')")
+   local icon, hl_group = require'nvim-web-devicons'.get_icon(filename, extension, { default = true })
+   if icon then
+     return icon
+   else
+     return ""
+   end
+  end
+EOF
+endif
+
 function! s:get_icon(buffer)
   if s:enable_devicons == 1 && exists('*WebDevIconsGetFileTypeSymbol')
     return WebDevIconsGetFileTypeSymbol(fnamemodify(bufname(a:buffer), ':t'))
+  elseif s:enable_devicons == 1 && has('nvim-0.5') && exists('g:nvim_web_devicons')
+    return v:lua._bufferline_get_icon(bufname(a:buffer))
   endif
 
   if s:enable_nerdfont == 1

--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -1,0 +1,16 @@
+local devicons = require('nvim-web-devicons')
+
+local M = {}
+
+M._get_icon = function (path)
+  local filename = vim.fn.fnamemodify(path, ':t')
+  local extension = vim.fn.fnamemodify(path, ':e')
+  local icon = devicons.get_icon(filename, extension, { default = true })
+  if icon then
+    return icon
+  else
+    return ""
+  end
+end
+
+return M


### PR DESCRIPTION
This PR adds support for [nvim-web-devicons](https://github.com/kyazdani42/nvim-web-devicons). Mind that this only works with neovim with lua support.

This PR is the second iteration of #68 which should help with issue on the vimscript as this approach are relying on the lua script which is native to neovim and minimal check on the vimscript itself.

Testing on the affected vim version are very much appreciated.