### PR TITLE
Fix nvim_web_devicons not working on Windows

### DIFF
--- a/autoload/lightline/bufferline.vim
+++ b/autoload/lightline/bufferline.vim
@@ -102,7 +102,7 @@ function! s:get_icon(buffer)
   if s:enable_devicons == 1 && exists('*WebDevIconsGetFileTypeSymbol')
     return WebDevIconsGetFileTypeSymbol(fnamemodify(bufname(a:buffer), ':t'))
   elseif s:enable_devicons == 1 && has('nvim-0.5') && exists('g:nvim_web_devicons')
-    return luaeval("require('bufferline')._get_icon('" . bufname(a:buffer) . "')")
+    return luaeval("require('bufferline')._get_icon(vim.fn.bufname(" . a:buffer . "))")
   endif
 
   if s:enable_nerdfont == 1


### PR DESCRIPTION
Since Windows use different path separator, when the expression is evaluated, a backslash should be escaped.

To help with that and to eliminate the risk of not escaping all the required characters, a buffer number is passed to the lua script directly and let it invoke `bufname` itself.