### PR TITLE
Add `filter_by_tabpage` configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,12 @@ Hides the bufferline by default and shows it if there are `n` or more tabs. Defa
 If `min_buffer_count` is also specified the bufferline will be shown if one of the conditions is met.
 This option can be useful if you are also displaying tabs in the lightline tabline.
 
+##### `g:lightline#bufferline#filter_by_tabpage`
+
+When more than one tab is opened, only buffers that are open in a window within the current tab are shown. When there
+is only one tab, all buffers are shown. Default is `0`.
+This option can be useful if you are also displaying tabs in the lightline tabline.
+
 ##### `g:lightline#bufferline#margin_left`
 
 The number of spaces to add on the left side of the buffer name. Default is `0`.

--- a/autoload/lightline/bufferline.vim
+++ b/autoload/lightline/bufferline.vim
@@ -8,6 +8,7 @@ let s:dirsep              = fnamemodify(getcwd(),':p')[-1:]
 let s:filename_modifier   = get(g:, 'lightline#bufferline#filename_modifier', ':.')
 let s:min_buffer_count    = get(g:, 'lightline#bufferline#min_buffer_count', 0)
 let s:min_tab_count       = get(g:, 'lightline#bufferline#min_tab_count', 0)
+let s:filter_by_tabpage   = get(g:, 'lightline#bufferline#filter_by_tabpage', 0)
 let s:auto_hide           = get(g:, 'lightline#bufferline#auto_hide', 0)
 let s:margin_left         = get(g:, 'lightline#bufferline#margin_left', 0)
 let s:margin_right        = get(g:, 'lightline#bufferline#margin_right', 0)
@@ -142,8 +143,16 @@ function! s:get_from_number_map(i)
   return l:result
 endfunction
 
+function! s:tabpage_filter(i)
+  if s:filter_by_tabpage && tabpagenr('$') > 1
+    return index(tabpagebuflist(tabpagenr()), a:i) != -1
+  endif
+  return 1
+endfunc
+
 function! s:filter_buffer(i)
   return bufexists(a:i) && buflisted(a:i) && !(getbufvar(a:i, '&filetype') ==# 'qf')
+       \ && s:tabpage_filter(a:i)
 endfunction
 
 function! s:filtered_buffers()


### PR DESCRIPTION
Allows limiting the buffers shown to that of the current tab page if more than one tab is open. This enables behavior similar to, but not quite the same as Airline's `tabline`.

The current behavior of having all buffers visible in the bufferline regardless of which tab page is opened is fine and is plenty useful as a visual reference when cycling buffers with `:bn` and `:bp` or similar. This option provides a supplementary view useful for when you're only interested in the buffers visible in the current tab, which can be particularly helpful when working on projects with many files open across multiple tabs.

Unlike #57, this PR is interested in *limiting* which buffers are shown rather than not showing them at all, nor does it circumvent any plugin logic; it is just another condition in `s:filter_buffer`, so it should play nice with the other configuration options. I attempted to adhere to the styling already in use, but wasn't sure about line length limits. Let me know if you'd like to see any changes.