### PR TITLE
Add support nvim-web-devicons  to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ The name to use for unnamed buffers. Default is `'*'`.
 
 ##### `g:lightline#bufferline#enable_devicons`
 
-Enables the usage of [vim-devicons](https://github.com/ryanoasis/vim-devicons) to display a filetype icon for the buffer.
+Enables the usage of [vim-devicons](https://github.com/ryanoasis/vim-devicons) or [nvim-web-devicons](https://github.com/kyazdani42/nvim-web-devicons) to display a filetype icon for the buffer.
 Default is `0`.
 
 ##### `g:lightline#bufferline#enable_nerdfont`


### PR DESCRIPTION
After using this plugin, I relized that it support nvim-web-devicons. But after I read README.md I think you forgot add it to README.md 