### PR TITLE
Implement the `click_handler_pre_command` option. Update the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,12 @@ If set to `1` the bufferline is clickable under Neovim versions with `tablineat`
 let g:lightline.component_raw = {'buffers': 1}
 ```
 
+You could provide additional command before the click handler is executed. For example, to always open the buffer in the right/main window even when the file explorer window is on focus.
+
+```viml
+let g:click_handler_pre_command = 'wincmd l'
+```
+
 ## Mappings
 
 This plugin provides Plug mappings to switch to buffers using their ordinal number in the bufferline.

--- a/autoload/lightline/bufferline.vim
+++ b/autoload/lightline/bufferline.vim
@@ -49,6 +49,10 @@ else
 endif
 
 function! lightline#bufferline#_click_handler(minwid, clicks, btn, modifiers)
+  let l:pre_command = get(g:, 'lightline#bufferline#click_handler_pre_command', '')
+  if l:pre_command != ''
+    execute l:pre_command
+  endif
   call s:goto_nth_buffer(a:minwid)
 endfunction
 


### PR DESCRIPTION
This is my usual window layout—file explorer (e.g. `netrw` or `coc-explorer`) in the sidebar, then the buffers in the right/main window:
  
<img width="1437" alt="Screen Shot 2022-01-23 at 2 30 57 AM" src="https://user-images.githubusercontent.com/4292088/150659808-4ed46ca1-dc19-4d7c-94e4-13ccc51d9887.png">

I think this is a quite common setup. However, one of the annoying behaviors of Vim is that when the file explorer  in sidebar is in focus, the opened file (via `:edit`, FZF open file triggers, etc) will be loaded in the file explorer section also, even when the main/editor window is available:

<img width="1434" alt="Screen Shot 2022-01-23 at 2 31 24 AM" src="https://user-images.githubusercontent.com/4292088/150659802-eff0130e-6080-40a4-8a08-ed7df7e81944.png">

This is not good UX, especially the buffer will be cramped in the narrow sidebar. Same behavior happens when `g:lightline#bufferline#clickable` is enabled. This makes the clicked buffer open in the sidebar. Ideally, opened file should load in the main window, even when the focus is on the sidebar, just like in other editors/IDEs. 

Hence, I added a `g:lightline#bufferline#click_handler_pre_command` option which could execute custom commands before the main click handler is executed. For example, in my use case, I want to make sure that the focus is always in the main window (`wincmd l`).

Tested to be working in various scenarios:
- custom command is specified: `let g:lightline#bufferline#click_handler_pre_command = 'wincmd l'`
- custom command is empty: `let g:lightline#bufferline#click_handler_pre_command = ''`
- `g:lightline#bufferline#click_handler_pre_command` option is not set.

PS: Thanks for this cool plugin, I'm using this for a long time already. :)