### PR TITLE
Emit a pre-click event in case the buffers are clickable

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,12 @@ If set to `1` the bufferline is clickable under Neovim versions with `tablineat`
 let g:lightline.component_raw = {'buffers': 1}
 ```
 
+Before the click handler for the buffer is executed a custom event `LightlineBufferlinePreClick` is emitted.
+To perform an operation before the buffer is switched via the click handler you can define an autocommand:
+```viml
+autocmd User LightlineBufferlinePreClick :echom "test"
+```
+
 ## Mappings
 
 This plugin provides Plug mappings to switch to buffers using their ordinal number in the bufferline.

--- a/autoload/lightline/bufferline.vim
+++ b/autoload/lightline/bufferline.vim
@@ -48,7 +48,15 @@ else
   let s:more_buffers_width = len(s:more_buffers) + 2
 endif
 
+if s:clickable
+  function! s:pre_click_handler()
+  endfunction
+
+  autocmd User LightlineBufferlinePreClick call s:pre_click_handler()
+endif
+
 function! lightline#bufferline#_click_handler(minwid, clicks, btn, modifiers)
+  doautocmd User LightlineBufferlinePreClick
   call s:goto_nth_buffer(a:minwid)
 endfunction
 


### PR DESCRIPTION
This allows executing a custom function before the click handler is performed. It is useful for switching views so that the buffer is opened in the right window. Fixes #100.